### PR TITLE
Fixed spectrumBuffer memory not being disposed

### DIFF
--- a/Assets/Scripts/FFTWater.cs
+++ b/Assets/Scripts/FFTWater.cs
@@ -548,6 +548,7 @@ public class FFTWater : MonoBehaviour {
         Destroy(spectrumTextures);
         Destroy(pingPongTex);
         Destroy(pingPongTex2);
+        spectrumBuffer.Dispose();
     }
 
     private void OnDrawGizmos() {


### PR DESCRIPTION
This fixes a minor issue where the memory used for the spectrumBuffer isn't being disposed of upon stopping the software. This fix can be found in OnDisable()